### PR TITLE
TODO管理機能ページの追加

### DIFF
--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -1,6 +1,7 @@
 import './bootstrap';
 import { MovieList } from './components/movieList';
 import { MovieCarousel } from './components/movieCarousel';
+import { TodoList } from './components/todoList';
 
 // DOMのロード完了時に実行
 document.addEventListener('DOMContentLoaded', () => {
@@ -28,5 +29,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const carouselElements = document.querySelectorAll('.relative.overflow-hidden');
   if (carouselElements.length > 0) {
     new MovieCarousel();
+  }
+
+  // TODO機能の初期化（todo.blade.php用）
+  const todoAppElement = document.getElementById('todo-app');
+  if (todoAppElement) {
+    new TodoList();
   }
 });

--- a/resources/js/components/todoList.ts
+++ b/resources/js/components/todoList.ts
@@ -1,0 +1,217 @@
+import { TodoItem, FilterType } from '@/types/todo';
+
+export class TodoList {
+  private todos: TodoItem[] = [];
+  private currentFilter: FilterType = 'all';
+  private readonly storageKey: string = 'pickup-movie-todos';
+  private readonly inputSelector: string = '#todo-input';
+  private readonly listSelector: string = '#todo-list';
+  private readonly addButtonSelector: string = '#add-todo-btn';
+  private readonly filterButtonsSelector: string = '[data-filter]';
+
+  constructor() {
+    this.loadFromStorage();
+    this.init();
+  }
+
+  private init(): void {
+    // 入力フォームのイベント
+    const input = document.querySelector(this.inputSelector) as HTMLInputElement;
+    const addButton = document.querySelector(this.addButtonSelector);
+
+    if (input && addButton) {
+      addButton.addEventListener('click', () => this.addTodo());
+      input.addEventListener('keypress', (e: KeyboardEvent) => {
+        if (e.key === 'Enter') {
+          this.addTodo();
+        }
+      });
+    }
+
+    // フィルターボタンのイベント
+    const filterButtons = document.querySelectorAll(this.filterButtonsSelector);
+    filterButtons.forEach(button => {
+      button.addEventListener('click', (e: Event) => {
+        const target = e.currentTarget as HTMLElement;
+        const filter = target.getAttribute('data-filter') as FilterType;
+        this.setFilter(filter);
+      });
+    });
+
+    // 初期レンダリング
+    this.render();
+  }
+
+  private addTodo(): void {
+    const input = document.querySelector(this.inputSelector) as HTMLInputElement;
+    if (!input) return;
+
+    const text = input.value.trim();
+    if (!text) return;
+
+    const newTodo: TodoItem = {
+      id: this.generateId(),
+      text,
+      completed: false,
+      createdAt: Date.now()
+    };
+
+    this.todos.unshift(newTodo);
+    this.saveToStorage();
+    this.render();
+
+    input.value = '';
+  }
+
+  private toggleTodo(id: string): void {
+    const todo = this.todos.find(t => t.id === id);
+    if (todo) {
+      todo.completed = !todo.completed;
+      this.saveToStorage();
+      this.render();
+    }
+  }
+
+  private deleteTodo(id: string): void {
+    this.todos = this.todos.filter(t => t.id !== id);
+    this.saveToStorage();
+    this.render();
+  }
+
+  private setFilter(filter: FilterType): void {
+    this.currentFilter = filter;
+    this.updateFilterButtons();
+    this.render();
+  }
+
+  private updateFilterButtons(): void {
+    const filterButtons = document.querySelectorAll(this.filterButtonsSelector);
+    filterButtons.forEach(button => {
+      const filter = button.getAttribute('data-filter');
+      if (filter === this.currentFilter) {
+        button.classList.add('bg-movie-panel-active');
+        button.classList.remove('bg-movie-panel');
+      } else {
+        button.classList.add('bg-movie-panel');
+        button.classList.remove('bg-movie-panel-active');
+      }
+    });
+  }
+
+  private getFilteredTodos(): TodoItem[] {
+    switch (this.currentFilter) {
+      case 'active':
+        return this.todos.filter(t => !t.completed);
+      case 'completed':
+        return this.todos.filter(t => t.completed);
+      default:
+        return this.todos;
+    }
+  }
+
+  private render(): void {
+    const list = document.querySelector(this.listSelector);
+    if (!list) return;
+
+    const filteredTodos = this.getFilteredTodos();
+
+    if (filteredTodos.length === 0) {
+      list.innerHTML = `
+        <div class="text-center py-8 text-movie-gray">
+          ${this.currentFilter === 'completed' ? 'まだ完了したTODOはありません' :
+            this.currentFilter === 'active' ? 'すべてのTODOが完了しています！' :
+            'TODOを追加してください'}
+        </div>
+      `;
+      return;
+    }
+
+    list.innerHTML = filteredTodos.map(todo => this.renderTodoItem(todo)).join('');
+
+    // イベントリスナーを再設定
+    this.attachTodoItemEvents();
+  }
+
+  private renderTodoItem(todo: TodoItem): string {
+    return `
+      <div class="bg-movie-panel rounded-lg p-4 flex items-center gap-3 group hover:bg-movie-panel-hover transition-colors" data-todo-id="${todo.id}">
+        <input
+          type="checkbox"
+          ${todo.completed ? 'checked' : ''}
+          class="w-5 h-5 rounded border-2 border-movie-light/30 bg-movie-dark checked:bg-movie-panel-active checked:border-movie-panel-active cursor-pointer transition-all todo-checkbox"
+          data-action="toggle"
+        />
+        <div class="flex-1 ${todo.completed ? 'line-through text-movie-muted' : 'text-movie-light'}">
+          ${this.escapeHtml(todo.text)}
+        </div>
+        <button
+          class="text-red-400 hover:text-red-300 opacity-0 group-hover:opacity-100 transition-opacity todo-delete-btn"
+          data-action="delete"
+          aria-label="削除"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd" />
+          </svg>
+        </button>
+      </div>
+    `;
+  }
+
+  private attachTodoItemEvents(): void {
+    // チェックボックスのイベント
+    const checkboxes = document.querySelectorAll('.todo-checkbox');
+    checkboxes.forEach(checkbox => {
+      checkbox.addEventListener('change', (e: Event) => {
+        const target = e.currentTarget as HTMLElement;
+        const todoItem = target.closest('[data-todo-id]') as HTMLElement;
+        const id = todoItem?.getAttribute('data-todo-id');
+        if (id) {
+          this.toggleTodo(id);
+        }
+      });
+    });
+
+    // 削除ボタンのイベント
+    const deleteButtons = document.querySelectorAll('.todo-delete-btn');
+    deleteButtons.forEach(button => {
+      button.addEventListener('click', (e: Event) => {
+        const target = e.currentTarget as HTMLElement;
+        const todoItem = target.closest('[data-todo-id]') as HTMLElement;
+        const id = todoItem?.getAttribute('data-todo-id');
+        if (id) {
+          this.deleteTodo(id);
+        }
+      });
+    });
+  }
+
+  private generateId(): string {
+    return `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+  }
+
+  private escapeHtml(text: string): string {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+  }
+
+  private loadFromStorage(): void {
+    try {
+      const stored = localStorage.getItem(this.storageKey);
+      if (stored) {
+        this.todos = JSON.parse(stored);
+      }
+    } catch (error) {
+      console.error('Failed to load todos from storage:', error);
+      this.todos = [];
+    }
+  }
+
+  private saveToStorage(): void {
+    try {
+      localStorage.setItem(this.storageKey, JSON.stringify(this.todos));
+    } catch (error) {
+      console.error('Failed to save todos to storage:', error);
+    }
+  }
+}

--- a/resources/js/types/todo.ts
+++ b/resources/js/types/todo.ts
@@ -1,0 +1,10 @@
+// TODOアイテムの型定義
+export interface TodoItem {
+  id: string;
+  text: string;
+  completed: boolean;
+  createdAt: number;
+}
+
+// フィルター種別
+export type FilterType = 'all' | 'active' | 'completed';

--- a/resources/views/movies/discover.blade.php
+++ b/resources/views/movies/discover.blade.php
@@ -48,6 +48,17 @@
         </picture>
     </div>
 
+    <!-- ツールリンク -->
+    <div class="mb-5 flex justify-center gap-3">
+        <a href="/todo" class="inline-flex items-center gap-1.5 py-1.5 px-3 bg-movie-panel rounded text-movie-light text-xs transition-colors hover:bg-movie-panel-hover">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z" />
+                <path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h6a1 1 0 100-2H7zm0 4a1 1 0 100 2h6a1 1 0 100-2H7z" clip-rule="evenodd" />
+            </svg>
+            TODO管理
+        </a>
+    </div>
+
     <div class="w-full flex justify-center mb-7">
         <div class="w-[800px] max-w-full min-h-[220px]">
             <div class="block w-full">

--- a/resources/views/tools/todo.blade.php
+++ b/resources/views/tools/todo.blade.php
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TODO管理 - Pickup Movie</title>
+    <meta name="referrer" content="strict-origin-when-cross-origin">
+    <meta name="description" content="Pickup MovieのTODO管理ツール。観たい映画や気になる映画をメモして管理できます。">
+
+    @if (app()->environment('development'))
+        @vite(['resources/css/app.css', 'resources/js/app.ts'])
+        <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('favicon/apple-touch-icon.png') }}">
+        <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('favicon/favicon-32x32.png') }}">
+        <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('favicon/favicon-16x16.png') }}">
+        <link rel="manifest" href="{{ asset('favicon/site.webmanifest') }}">
+        <link rel="shortcut icon" href="{{ asset('favicon/favicon.ico') }}">
+    @else
+        @php
+            $manifest = json_decode(file_get_contents(public_path('build/manifest.json')), true);
+        @endphp
+        <link rel="stylesheet" href="{{ secure_asset('build/' . $manifest['resources/css/app.css']['file']) }}">
+        <script type="module" src="{{ secure_asset('build/' . $manifest['resources/js/app.ts']['file']) }}"></script>
+        <link rel="apple-touch-icon" sizes="180x180" href="{{ secure_asset('favicon/apple-touch-icon.png') }}">
+        <link rel="icon" type="image/png" sizes="32x32" href="{{ secure_asset('favicon/favicon-32x32.png') }}">
+        <link rel="icon" type="image/png" sizes="16x16" href="{{ secure_asset('favicon/favicon-16x16.png') }}">
+        <link rel="manifest" href="{{ secure_asset('favicon/site.webmanifest') }}">
+        <link rel="shortcut icon" href="{{ secure_asset('favicon/favicon.ico') }}">
+    @endif
+</head>
+<body class="bg-movie-dark text-movie-light font-sans px-3 sm:px-5 pt-3 pb-5 w-full overflow-x-hidden">
+<div class="max-w-[800px] w-full mx-auto relative block">
+    <!-- ヘッダー -->
+    <div class="mb-6 px-2.5 text-center w-full">
+        <a href="/" class="inline-block mb-4">
+            <picture>
+                @if (app()->environment('development'))
+                    <source srcset="{{ asset('images/logo.webp') }}" type="image/webp">
+                    <img src="{{ asset('images/logo.png') }}"
+                         alt="Pickup Movie ロゴ"
+                         class="mx-auto w-[180px] sm:w-[220px] h-auto">
+                @else
+                    <source srcset="{{ secure_asset('images/logo.webp') }}" type="image/webp">
+                    <img src="{{ secure_asset('images/logo.png') }}"
+                         alt="Pickup Movie ロゴ"
+                         class="mx-auto w-[180px] sm:w-[220px] h-auto">
+                @endif
+            </picture>
+        </a>
+        <h1 class="text-2xl font-bold text-movie-light mb-2">TODO管理</h1>
+        <p class="text-sm text-movie-gray">観たい映画や気になることをメモしておきましょう</p>
+    </div>
+
+    <!-- ホームに戻るリンク -->
+    <div class="mb-6 text-center">
+        <a href="/" class="inline-flex items-center gap-2 py-2 px-4 bg-movie-panel rounded text-movie-light text-sm transition-colors hover:bg-movie-panel-hover">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z" />
+            </svg>
+            ホームに戻る
+        </a>
+    </div>
+
+    <!-- TODO App Container -->
+    <div id="todo-app" class="w-full">
+        <!-- 入力フォーム -->
+        <div class="mb-6 bg-movie-panel rounded-lg p-4 sm:p-6">
+            <div class="flex flex-col sm:flex-row gap-3">
+                <input
+                    type="text"
+                    id="todo-input"
+                    placeholder="TODOを入力してください..."
+                    class="flex-1 px-4 py-3 bg-movie-dark text-movie-light rounded border-2 border-movie-light/20 focus:border-movie-panel-active focus:outline-none transition-colors"
+                />
+                <button
+                    id="add-todo-btn"
+                    class="px-6 py-3 bg-movie-panel-active text-movie-light rounded font-medium hover:bg-opacity-80 transition-all hover:scale-105 whitespace-nowrap"
+                >
+                    追加
+                </button>
+            </div>
+        </div>
+
+        <!-- フィルターボタン -->
+        <div class="mb-4 flex justify-center gap-2 flex-wrap">
+            <button
+                data-filter="all"
+                class="py-2 px-4 bg-movie-panel-active rounded text-movie-light text-sm transition-colors hover:bg-movie-panel-hover"
+            >
+                すべて
+            </button>
+            <button
+                data-filter="active"
+                class="py-2 px-4 bg-movie-panel rounded text-movie-light text-sm transition-colors hover:bg-movie-panel-hover"
+            >
+                未完了
+            </button>
+            <button
+                data-filter="completed"
+                class="py-2 px-4 bg-movie-panel rounded text-movie-light text-sm transition-colors hover:bg-movie-panel-hover"
+            >
+                完了済み
+            </button>
+        </div>
+
+        <!-- TODOリスト -->
+        <div id="todo-list" class="space-y-3">
+            <!-- TODOアイテムはJavaScriptで動的に生成されます -->
+            <div class="text-center py-8 text-movie-gray">
+                TODOを追加してください
+            </div>
+        </div>
+    </div>
+
+    <!-- 注意書き -->
+    <div class="mt-8 text-center text-xs text-movie-muted">
+        <p>TODOはブラウザのローカルストレージに保存されます</p>
+        <p class="mt-1">ブラウザのデータを削除すると、TODOも削除されますのでご注意ください</p>
+    </div>
+</div>
+
+<footer class="w-full text-center text-sm text-movie-muted mt-10 pt-10 border-t border-movie-panel">
+    <div class="flex justify-center gap-5">
+        <a href="/terms" class="hover:underline">利用規約</a>
+        <a href="/privacy" class="hover:underline">プライバシーポリシー</a>
+    </div>
+    <div class="mt-3">&copy; {{ date('Y') }} Pickup Movie</div>
+</footer>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,3 +9,4 @@ Route::get('/load-more', [MovieController::class, 'loadMore']);
 Route::get('/movies/{id}', [MovieController::class, 'show'])->where('id', '[0-9]+');
 Route::view('/terms', 'movies.terms');
 Route::view('/privacy', 'movies.privacy');
+Route::view('/todo', 'tools.todo');


### PR DESCRIPTION
## 概要
Issue #2の要件を満たすTODO管理ページを実装しました。

## 実装内容
- ✅ TODO追加、完了/未完了切り替え、削除機能
- ✅ フィルタリング機能（全て/未完了/完了済み）
- ✅ localStorageによる永続化
- ✅ 一覧ページ（discover.blade.php）にTODOページへのリンクを追加
- ✅ TypeScript + Tailwind CSSで実装

## 変更ファイル
- `routes/web.php`: `/todo`ルート追加
- `resources/views/tools/todo.blade.php`: TODOページのビュー（新規）
- `resources/js/types/todo.ts`: 型定義（新規）
- `resources/js/components/todoList.ts`: TODO管理ロジック（新規）
- `resources/js/app.ts`: TODOコンポーネント初期化処理追加
- `resources/views/movies/discover.blade.php`: TODOページへのリンク追加

## テスト方法
1. アプリケーションを起動
2. 一覧ページ（discover）上部の「TODO管理」リンクをクリック
3. TODOの追加、完了切り替え、削除、フィルタリングが正常に動作することを確認
4. ページをリロードしてもTODOが永続化されていることを確認

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)